### PR TITLE
feat: Add pause/resume functionality


### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub struct Eta {
     recent_time: Instant,
     total_time_elapsed: usize,
     time_accuracy: TimeAcc,
-    paused: Option<Instant>,
+    paused: (Option<Instant>, usize),
 }
 
 /* pub struct EtaMessageFormat {
@@ -33,7 +33,7 @@ impl Eta {
             recent_time: Instant::now(),
             total_time_elapsed: 0,
             time_accuracy,
-            paused: None,
+            paused: (None, 0),
         }
     }
 
@@ -46,24 +46,25 @@ impl Eta {
     }
 
     pub fn pause(&mut self) {
-        if self.paused.is_none() {
-            self.paused = Some(Instant::now());
+        if self.paused.0.is_none() {
+            self.paused.0 = Some(Instant::now());
+            self.paused.1 += self.elapsed();
         }
     }
 
     pub fn resume(&mut self) {
-        if !self.paused.is_none() {
+        if self.paused.0.is_some() {
             self.recent_time = Instant::now();
-            self.paused = None;
+            self.paused.0 = None;
         }
     }
 
     pub fn step(&mut self) {
-        if self.paused.is_none() {
-            self.tasks_done += 1;
-            self.total_time_elapsed += self.elapsed();
-            self.recent_time = Instant::now();
-        }
+        self.tasks_done += 1;
+        self.total_time_elapsed += self.elapsed() + self.paused.1;
+        self.recent_time = Instant::now();
+        self.paused.0 = None;
+        self.paused.1 = 0;
     }
 
     fn elapsed(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,10 @@ impl Eta {
 
     pub fn step(&mut self) {
         self.tasks_done += 1;
-        self.total_time_elapsed += self.elapsed() + self.paused.1;
+        if self.paused.0.is_none() {
+            self.total_time_elapsed += self.elapsed();
+        }
+        self.total_time_elapsed += self.paused.1;
         self.recent_time = Instant::now();
         self.paused.0 = None;
         self.paused.1 = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,17 +45,25 @@ impl Eta {
         Eta::create_instance(tasks_count, time_accuracy, tasks_done)
     }
 
-    /*fn pause(&self){
-        //tbd
+    pub fn pause(&mut self) {
+        if self.paused.is_none() {
+            self.paused = Some(Instant::now());
+        }
     }
-    fn resume(&self){
-        //tbd
-    }*/
+
+    pub fn resume(&mut self) {
+        if !self.paused.is_none() {
+            self.recent_time = Instant::now();
+            self.paused = None;
+        }
+    }
 
     pub fn step(&mut self) {
-        self.tasks_done += 1;
-        self.total_time_elapsed += self.elapsed();
-        self.recent_time = Instant::now();
+        if self.paused.is_none() {
+            self.tasks_done += 1;
+            self.total_time_elapsed += self.elapsed();
+            self.recent_time = Instant::now();
+        }
     }
 
     fn elapsed(&self) -> usize {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,11 +91,11 @@ mod tests {
         let mut eta = Eta::new(10, TimeAcc::SEC);
         sleep(Duration::from_secs(1));
         eta.pause();
-        sleep(Duration::from_secs(3));
+        sleep(Duration::from_secs(1));
         eta.resume();
-        sleep(Duration::from_secs(7));
+        sleep(Duration::from_secs(1));
         eta.pause();
-        sleep(Duration::from_secs(15));
+        sleep(Duration::from_secs(1));
         eta.step();
         assert_eq!(eta.total_time_elapsed, 2);
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,4 +45,16 @@ mod tests {
         eta.step();
         assert!(eta.total_time_elapsed > 0);
     }
+
+    #[test]
+    fn test_eta_pause() {
+        let mut eta = Eta::new(10, TimeAcc::MILLI);
+        eta.step();
+        eta.pause();
+        sleep(Duration::from_millis(20));
+        eta.step();
+        eta.resume();
+        eta.step();
+        assert!(eta.total_time_elapsed < 10);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ mod tests {
         assert_eq!(eta.tasks_done, 0);
         assert_eq!(eta.time_accuracy, TimeAcc::SEC);
         assert_eq!(eta.total_time_elapsed, 0);
-        assert_eq!(eta.paused, None);
+        assert_eq!(eta.paused, (None, 0));
     }
 
     #[test]
@@ -21,7 +21,7 @@ mod tests {
         assert_eq!(eta.tasks_done, 5);
         assert_eq!(eta.time_accuracy, TimeAcc::SEC);
         assert_eq!(eta.total_time_elapsed, 0);
-        assert_eq!(eta.paused, None);
+        assert_eq!(eta.paused, (None, 0));
     }
 
     #[test]
@@ -39,22 +39,72 @@ mod tests {
     }
 
     #[test]
-    fn test_eta_elapsed_time() {
-        let mut eta = Eta::new(10, TimeAcc::NANO);
-        sleep(Duration::from_millis(1));
+    fn test_eta_total_elapsed_time() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
+        sleep(Duration::from_secs(1));
         eta.step();
         assert!(eta.total_time_elapsed > 0);
     }
 
     #[test]
     fn test_eta_pause() {
-        let mut eta = Eta::new(10, TimeAcc::MILLI);
-        eta.step();
+        let mut eta = Eta::new(10, TimeAcc::SEC);
         eta.pause();
-        sleep(Duration::from_millis(20));
+        assert!(eta.paused.0.is_some());
+    }
+
+    #[test]
+    fn test_eta_resume() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
+        eta.pause();
+        eta.resume();
+        assert!(eta.paused.0.is_none());
+    }
+
+    #[test]
+    fn test_eta_progress() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
         eta.step();
+        assert_eq!(eta.progress(), 0.1);
+    }
+
+    #[test]
+    fn test_eta_time_remaining() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
+        sleep(Duration::from_secs(1));
+        eta.step();
+        assert_eq!(eta.time_remaining(), 9);
+    }
+
+    #[test]
+    fn test_eta_time_remaining_paused() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
+        eta.pause();
+        sleep(Duration::from_secs(1));
         eta.resume();
         eta.step();
-        assert!(eta.total_time_elapsed < 10);
+        assert_eq!(eta.total_time_elapsed, 0);
+    }
+
+    #[test]
+    fn test_eta_complex_paused() {
+        let mut eta = Eta::new(10, TimeAcc::SEC);
+        sleep(Duration::from_secs(1));
+        eta.pause();
+        sleep(Duration::from_secs(3));
+        eta.resume();
+        sleep(Duration::from_secs(7));
+        eta.pause();
+        sleep(Duration::from_secs(15));
+        eta.step();
+        assert_eq!(eta.total_time_elapsed, 2);
+    }
+
+    #[test]
+    fn test_timeacc_display() {
+        assert_eq!(format!("{}", TimeAcc::SEC), "s");
+        assert_eq!(format!("{}", TimeAcc::MILLI), "ms");
+        assert_eq!(format!("{}", TimeAcc::MICRO), "us");
+        assert_eq!(format!("{}", TimeAcc::NANO), "ns");
     }
 }


### PR DESCRIPTION
- Added pause and resume methods which completely stop time tracking for eta
- Modified step method to only work when not eta is not paused
- Added unit test for pause and resume